### PR TITLE
 Implement pagination for search/filtering results, fixes #5

### DIFF
--- a/declarations_site/catalog/paginator.py
+++ b/declarations_site/catalog/paginator.py
@@ -2,7 +2,6 @@ from django.core.paginator import Paginator, Page
 from django.utils import six
 from django.conf import settings
 
-
 from elasticsearch_dsl.result import Response
 
 
@@ -21,7 +20,7 @@ class ElasticPage(Page):
     def __getitem__(self, index):
         if not isinstance(index, (slice,) + six.integer_types):
             raise TypeError
-        # The object_list is converted to a Response so that it result can be
+        # The object_list is converted to a Response so that its result can be
         # used as a normal iterable. Doesn't trigger more than one hit too.
         if not isinstance(self.object_list, Response):
             self.object_list = self.object_list.execute()

--- a/declarations_site/catalog/paginator.py
+++ b/declarations_site/catalog/paginator.py
@@ -1,0 +1,80 @@
+from django.core.paginator import Paginator, Page
+from django.utils import six
+from django.conf import settings
+
+
+from elasticsearch_dsl.result import Response
+
+
+class ElasticPaginator(Paginator):
+    """Implementation of Django's Paginator that makes amends for
+    Elasticsearch DSL search object details. Pass a search object to the
+    constructor as `object_list` parameter."""
+    def _get_page(self, *args, **kwargs):
+        return ElasticPage(*args, **kwargs)
+
+
+class ElasticPage(Page):
+    def __len__(self):
+        raise NotImplemented
+
+    def __getitem__(self, index):
+        if not isinstance(index, (slice,) + six.integer_types):
+            raise TypeError
+        # The object_list is converted to a Response so that it result can be
+        # used as a normal iterable. Doesn't trigger more than one hit too.
+        if not isinstance(self.object_list, Response):
+            self.object_list = self.object_list.execute()
+        return self.object_list[index]
+
+    @property
+    def contextual_page_range(self):
+        """Determines a list of page numbers based on current page and total
+        number of pages. Includes one page to each side of the current one or
+        two to the side at edges.
+
+        Taken and adapted from:
+        https://gist.github.com/tomchristie/321140cebb1c4a558b15"""
+        current = self.number
+        final = self.paginator.num_pages
+
+        # If it's small enough - just show them all
+        if final <= 5:
+            return self.paginator.page_range
+
+        # We always include the first two pages, last two pages, and
+        # two pages either side of the current page.
+        included = set((
+            1,
+            current - 1, current, current + 1,
+            final
+        ))
+
+        # If the break would only exclude a single page number then we
+        # may as well include the page number instead of the break.
+        if current <= 4:
+            included.add(2)
+            included.add(3)
+        if current >= final - 3:
+            included.add(final - 1)
+            included.add(final - 2)
+
+        # Now sort the page numbers and drop anything outside the limits.
+        included = [
+            idx for idx in sorted(list(included))
+            if idx > 0 and idx <= final
+        ]
+
+        # Finally insert any `...` breaks
+        if current > 4:
+            included.insert(1, None)
+        if current < final - 3:
+            included.insert(len(included) - 1, None)
+        return included
+
+
+def paginated_search(request, search):
+    """Helper function that handles common pagination pattern."""
+    paginator = ElasticPaginator(search, settings.CATALOG_PER_PAGE)
+    page = request.GET.get('page', 1)
+    return paginator.page(page)

--- a/declarations_site/catalog/templates/results.jinja
+++ b/declarations_site/catalog/templates/results.jinja
@@ -51,15 +51,15 @@
                 {% endfor %}
             </div>
             <ul class="pagination">
-                <li{% if not results.has_previous() %} class="disabled"{% endif %}><a href="{% if results.has_previous() %}?{{ updated_queryset(request, {'page': results.previous_page_number()}) }}{% endif %}">«</a></li>
+                <li{% if not results.has_previous() %} class="disabled"{% endif %}><a href="{% if results.has_previous() %}?{{ updated_querystring(request, {'page': results.previous_page_number()}) }}{% endif %}">«</a></li>
                 {% for page_num in results.contextual_page_range %}
                 {% if page_num == None %}
                     <li class="disabled"><a href="#">&hellip;</a></li>
                 {% else %}
-                    <li{% if results.number == page_num %} class="active"{% endif %}><a href="?{{ updated_queryset(request, {'page': page_num}) }}">{{ page_num }}</a></li>
+                    <li{% if results.number == page_num %} class="active"{% endif %}><a href="?{{ updated_querystring(request, {'page': page_num}) }}">{{ page_num }}</a></li>
                 {% endif %}
                 {% endfor %}
-                <li{% if not results.has_next() %} class="disabled"{% endif %}><a href="{% if results.has_next() %}?{{ updated_queryset(request, {'page': results.next_page_number()}) }}{% endif %}">»</a></li>
+                <li{% if not results.has_next() %} class="disabled"{% endif %}><a href="{% if results.has_next() %}?{{ updated_querystring(request, {'page': results.next_page_number()}) }}{% endif %}">»</a></li>
             </ul>
         </div>
     </div>

--- a/declarations_site/catalog/templates/results.jinja
+++ b/declarations_site/catalog/templates/results.jinja
@@ -50,6 +50,17 @@
                 {% endif %}
                 {% endfor %}
             </div>
+            <ul class="pagination">
+                <li{% if not results.has_previous() %} class="disabled"{% endif %}><a href="{% if results.has_previous() %}?{{ updated_queryset(request, {'page': results.previous_page_number()}) }}{% endif %}">«</a></li>
+                {% for page_num in results.contextual_page_range %}
+                {% if page_num == None %}
+                    <li class="disabled"><a href="#">&hellip;</a></li>
+                {% else %}
+                    <li{% if results.number == page_num %} class="active"{% endif %}><a href="?{{ updated_queryset(request, {'page': page_num}) }}">{{ page_num }}</a></li>
+                {% endif %}
+                {% endfor %}
+                <li{% if not results.has_next() %} class="disabled"{% endif %}><a href="{% if results.has_next() %}?{{ updated_queryset(request, {'page': results.next_page_number()}) }}{% endif %}">»</a></li>
+            </ul>
         </div>
     </div>
 </section>

--- a/declarations_site/catalog/templatetags/catalog.py
+++ b/declarations_site/catalog/templatetags/catalog.py
@@ -4,9 +4,9 @@ register = Library()
 
 
 @register.global_function
-def updated_queryset(request, params):
-    """Updates current queryset with a given dict of params, removing existing
-    occurrences of such params. Returns a urlencoded querystring."""
+def updated_querystring(request, params):
+    """Updates current querystring with a given dict of params, removing
+    existing occurrences of such params. Returns a urlencoded querystring."""
     original_params = request.GET.copy()
     for key in params:
         if key in original_params:

--- a/declarations_site/catalog/templatetags/catalog.py
+++ b/declarations_site/catalog/templatetags/catalog.py
@@ -1,0 +1,15 @@
+from django_jinja.library import Library
+
+register = Library()
+
+
+@register.global_function
+def updated_queryset(request, params):
+    """Updates current queryset with a given dict of params, removing existing
+    occurrences of such params. Returns a urlencoded querystring."""
+    original_params = request.GET.copy()
+    for key in params:
+        if key in original_params:
+            original_params.pop(key)
+    original_params.update(params)
+    return original_params.urlencode()

--- a/declarations_site/catalog/views.py
+++ b/declarations_site/catalog/views.py
@@ -1,9 +1,11 @@
 from django.shortcuts import render
 from django.http import JsonResponse, Http404
+
 from elasticsearch.exceptions import NotFoundError
 from elasticsearch_dsl.filter import Term, Not
 
 from catalog.elastic_models import Declaration
+from catalog.paginator import paginated_search
 
 
 def home(request):
@@ -37,12 +39,11 @@ def suggest(request):
 
 def search(request):
     query = request.GET.get("q", "")
-    results = Declaration.search().query(
-        "match", _all=query)[:30]
+    search = Declaration.search().query("match", _all=query)
 
     return render(request, "results.jinja", {
         "query": query,
-        "results": results.execute()
+        "results": paginated_search(request, search)
     })
 
 
@@ -92,15 +93,15 @@ def region_office(request, region_name, office_name):
 
     return render(request, 'results.jinja', {
         'query': office_name,
-        'results': search.execute()
+        'results': paginated_search(request, search)
     })
 
 
 def office(request, office_name):
     search = Declaration.search()\
-        .filter('term', general__post__office=office_name)[:30]
+        .filter('term', general__post__office=office_name)
 
     return render(request, 'results.jinja', {
         'query': office_name,
-        'results': search.execute()
+        'results': paginated_search(request, search)
     })

--- a/declarations_site/declarations_site/settings.py
+++ b/declarations_site/declarations_site/settings.py
@@ -58,6 +58,7 @@ TEMPLATE_CONTEXT_PROCESSORS = (
     "django.core.context_processors.media",
     "django.core.context_processors.static",
     "django.core.context_processors.tz",
+    "django.core.context_processors.request",
     "django.contrib.messages.context_processors.messages",
     "catalog.context_processors.stats_processor"
 )
@@ -82,8 +83,8 @@ USE_TZ = True
 
 
 TEMPLATE_LOADERS = (
-    'django_jinja.loaders.FileSystemLoader',
     'django_jinja.loaders.AppLoader',
+    'django_jinja.loaders.FileSystemLoader',
 )
 DEFAULT_JINJA2_TEMPLATE_EXTENSION = '.jinja'
 JINJA2_EXTENSIONS = ["pipeline.jinja2.ext.PipelineExtension"]
@@ -135,6 +136,9 @@ STATIC_URL = '/static/'
 
 # We have no DB so far, so just use cookies as the storage
 SESSION_ENGINE = 'django.contrib.sessions.backends.signed_cookies'
+
+# Application settings
+CATALOG_PER_PAGE = 30
 
 
 try:


### PR DESCRIPTION
- Implements an ES-minded subclass of Django's Paginator
- Adds a contextual page numbering
- Adds a helper Jinja2 global for updating querystrings
- Adds a pagination widget to the results template
- Corresponding view changes
