### PR TITLE
Removes "empty" inner dicts in list fields of Declaration

### DIFF
--- a/declarations_site/catalog/management/commands/fixlists.py
+++ b/declarations_site/catalog/management/commands/fixlists.py
@@ -1,0 +1,29 @@
+from django.core.management.base import BaseCommand
+
+from catalog.elastic_models import Declaration
+
+
+class Command(BaseCommand):
+    help = 'Removes empty list items from previous versions of vulyk import'
+
+    def handle(self, *args, **options):
+        all_decls = Declaration.search().query('match_all').scan()
+        for decl in all_decls:
+            print('Processing decl for {}'.format(decl.general.full_name))
+            for parent, field_key in self._decl_list_fields(decl):
+                field = getattr(parent, field_key, None)
+                if field:
+                    filtered_field = list(filter(self._values_filter, field))
+                    setattr(parent, field_key, filtered_field)
+            decl.save()
+
+    def _values_filter(self, field):
+        return any([v for k, v in field._d_.items() if not k.endswith('_units')])
+
+    def _decl_list_fields(self, decl):
+        return [(decl.general, 'family'), (decl.income, '21'), (decl.income, '22'), (decl.income, '23'),
+                (decl.estate, '24'), (decl.estate, '25'), (decl.estate, '26'), (decl.estate, '27'), (decl.estate, '28'),
+                (decl.estate, '29'), (decl.estate, '30'), (decl.estate, '31'), (decl.estate, '32'), (decl.estate, '33'),
+                (decl.estate, '34'), (decl.vehicle, '35'), (decl.vehicle, '36'), (decl.vehicle, '37'),
+                (decl.vehicle, '38'), (decl.vehicle, '39'), (decl.vehicle, '40'), (decl.vehicle, '41'),
+                (decl.vehicle, '42'), (decl.vehicle, '43'), (decl.vehicle, '44'), (decl.general, 'addresses')]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 Django==1.8.3
-django-jinja==1.4.1
+django-jinja==2.1.1
 elasticsearch==2.1.0
 elasticsearch-dsl==0.0.9
 Jinja2==2.8


### PR DESCRIPTION
This is an issue with imports from Vulyk as CSVs contain inner
structures that may be empty. So Vulyk dataset import needs to check if
an inner structure is actually empty and in this case ignore the list
element. Includes a script to apply this retrospectively.

Refs #43.
