### PR TITLE
fix spotter bugs, add user edit_email form

### DIFF
--- a/declarations_site/catalog/static/js/main.js
+++ b/declarations_site/catalog/static/js/main.js
@@ -1,8 +1,8 @@
 document.addEventListener(
-    "touchstart", 
+    "touchstart",
     function(){},
     true
-); 
+);
 
 $(function() {
     function setColumnsHeights (list, item) {
@@ -31,7 +31,7 @@ $(function() {
     function hideme($ib) {
         $ib.css("height", 10);
     }
-       
+
     $("#infobox a#closeme").on("click", function() {
         $ib = $('#infobox');
 
@@ -41,7 +41,7 @@ $(function() {
             .one('webkitAnimationEnd mozAnimationEnd MSAnimationEnd oanimationend animationend',
                 hideme($ib));
     });
-   
+
     $('#list').on("click", function(event){
         event.preventDefault();
         $('.search-results .item').addClass('list-group-item');
@@ -81,6 +81,16 @@ $(function() {
             }
         });
 
+        // submit search form on enter (fix typeahead)
+        $('#search-form').on('keydown', function(e) {
+            if (e.keyCode == 13) {
+                var ta = $(this).data('typeahead'),
+                    val = ta.$menu.find('.active').data('value');
+                if (val)
+                    $('#search-form').val(val);
+                $('#front-searchbox form').submit();
+            }
+        });
     });
 
     $( window ).load(function() {

--- a/declarations_site/catalog/static/js/user.js
+++ b/declarations_site/catalog/static/js/user.js
@@ -15,7 +15,7 @@ $(function() {
 
     function setLoginNext(href) {
         if (href && href.search(/\?/) > 0)
-            href = escape(href);
+            href = encodeURI(href);
         $('#login-modal #signin a').each(function () {
             this.href = this.href.replace(/next=[^&]+/, 'next=' + href);
         });
@@ -40,7 +40,7 @@ $(function() {
                 localStorage.removeItem(username_key);
         });
 
-        $('#save-search').click(function (e) {
+        $('.save-search').click(function (e) {
             $(document.body).addClass('wait')
                 .css({'cursor' : 'wait'});
             $('#wait-modal').modal('show');
@@ -51,7 +51,7 @@ $(function() {
     }
 
     function userNotAuthenticated() {
-        var ss = $('#save-search');
+        var ss = $('a.save-search');
         if (ss.length) {
             setLoginNext(ss.attr('href'));
             ss.click(function (e) {
@@ -83,22 +83,11 @@ $(function() {
         }
     });
 
-    // submit search form on enter (fix typeahead)
-    $('#search-form').on('keydown', function(e) {
-        if (e.keyCode == 13) {
-            var ta = $(this).data('typeahead'),
-                val = ta.$menu.find('.active').data('value');
-            if (val)
-                $('#search-form').val(val);
-            $('#front-searchbox form').submit();
-        }
-    });
-
     location_href = window.location.pathname + window.location.search;
 
     // get user menu via ajax
     $.ajax({
-        url: '/user/login-menu/?next=' + escape(location_href),
+        url: '/user/login-menu/?next=' + encodeURI(location_href),
     }).done(function (data) {
         if (data.search('logout') > 0) {
             userIsAuthenticated(data, username_key);

--- a/declarations_site/catalog/static/sass/_user.scss
+++ b/declarations_site/catalog/static/sass/_user.scss
@@ -95,3 +95,13 @@ span.social .save-search {
         color: #e95000;
     }
 }
+
+.form-group .help-block-text,
+.form-group .help-block-error {
+    position: static;
+    display: block;
+}
+
+.help-footer {
+    margin-top: 50px;
+}

--- a/declarations_site/declarations_site/settings.py
+++ b/declarations_site/declarations_site/settings.py
@@ -104,6 +104,7 @@ AUTHENTICATION_BACKENDS = (
     'django.contrib.auth.backends.ModelBackend',
 )
 
+SOCIAL_AUTH_RAISE_EXCEPTIONS = False
 SOCIAL_AUTH_ADMIN_USER_SEARCH_FIELDS = ['username', 'first_name', 'email']
 SOCIAL_AUTH_CLEAN_USERNAME_FUNCTION = 'spotter.utils.clean_username'
 SOCIAL_AUTH_PIPELINE = (
@@ -128,13 +129,11 @@ SOCIAL_AUTH_FACEBOOK_SCOPE = ['email']
 SOCIAL_AUTH_FACEBOOK_PROFILE_EXTRA_PARAMS = {'fields': 'id,name,email'}
 LOGOUT_REDIRECT = '/'
 
+# EMAIL_SITE_URL used for full hrefs in email templates
+EMAIL_SITE_URL = 'https://declarations.com.ua'
 
 FROM_EMAIL = 'robot@declarations.com.ua'
 EMAIL_HOST = 'localhost'
-# EMAIL_HOST_USER = ''
-# EMAIL_HOST_PASSWORD = ''
-# EMAIL_PORT = 587
-# EMAIL_USE_TLS = True
 
 
 LANGUAGE_CODE = 'uk-ua'

--- a/declarations_site/spotter/forms.py
+++ b/declarations_site/spotter/forms.py
@@ -1,0 +1,5 @@
+from django import forms
+
+
+class UserProfileForm(forms.Form):
+    email = forms.EmailField(label='E-mail', max_length=100)

--- a/declarations_site/spotter/templates/_spotter.jinja
+++ b/declarations_site/spotter/templates/_spotter.jinja
@@ -18,7 +18,7 @@
                     <div class="modal-header">
                         <button type="button" class="close" data-dismiss="modal" aria-label="x"><span
                             aria-hidden="true">×</span></button>
-                        <h4 class="modal-title" id="login-label">Будь ласка увійдіть</h4>
+                        <h4 class="modal-title" id="login-label">Будь ласка, увійдіть</h4>
                     </div>
                     <div class="modal-body text-center">
                         <p>Щоб розпочати моніторинг необхідно авторизуватись</p>
@@ -49,4 +49,17 @@
             </div>
         </div>
     </div>
+{%- endmacro %}
+{% macro flash_messages(messages) -%}
+    {% if messages %}
+    <div class="messages">
+        {% for message in messages %}
+        <div class="alert alert-dismissible alert-{% if message.tags %}{{ message.tags }}{% endif %}">
+            <button type="button" class="close" data-dismiss="alert"
+                aria-label="Close"><span aria-hidden="true">&times;</span></button>
+            {{ message }}
+        </div>
+        {% endfor %}
+    </div>
+    {% endif %}
 {%- endmacro %}

--- a/declarations_site/spotter/templates/edit_email.jinja
+++ b/declarations_site/spotter/templates/edit_email.jinja
@@ -1,0 +1,51 @@
+{% extends "base.jinja" %}
+
+{% from "_spotter.jinja" import flash_messages %}
+
+{% block html_title -%}Мій профіль{%- endblock %}
+
+
+{% block content %}
+<section id="page">
+    <div class="container">
+        <div id="breadcrumbs">
+            <ol class="breadcrumb">
+                <li><a href="/">Головна</a></li>
+                <li class="active">Мій профіль</li>
+            </ol>
+        </div>
+        {{ flash_messages(messages) }}
+        <h1 id="page-header"><span>Мій профіль</span></h1>
+        <div class="page-content">
+            <div class="box row">
+                <form class="form col-md-4" method="post">
+                    <p>Для продовження необхідно вказати свій e-mail.</p>
+                    {% csrf_token %}
+                    {% for field in form %}
+                        <div class="row form-group{% if field.errors %} has-error{% endif %}">
+                            <label for="id_{{ field.name }}">{{ field.label }}</label>
+                            <div>
+                                {{ field|replace('/>', ' class="form-control"/>')|safe }}
+                                {% if field.errors %}
+                                <span class="help-block help-block-error">
+                                    {% for error in  field.errors %}{{ error }}{% endfor %}
+                                </span>
+                                {% endif %}
+                                {% if field.help_text %}
+                                    <p class="help-block help-block-text"><small>{{ field.help_text }}</small></p>
+                                {% endif %}
+                            </div>
+                        </div>
+                    {% endfor %}
+                    <div class="form-group">
+                        <div>
+                            <button type="submit" class="btn btn-primary btn-raised">Зберегти</button>
+                        </div>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</section>
+
+{% endblock %}

--- a/declarations_site/spotter/templates/email_found_message.html
+++ b/declarations_site/spotter/templates/email_found_message.html
@@ -15,7 +15,7 @@
 	</p>
 
 	{% for declaration in decl_list %}
-	<p><a href="https://declarations.com.ua/declaration/{{ declaration.meta.id }}">{{ declaration.general.last_name }}
+	<p><a href="{{ site_url }}{% url 'details' declaration.meta.id %}">{{ declaration.general.last_name }}
 			{{ declaration.general.name }} {{ declaration.general.patronymic }}</a><br>
 		{% if declaration.intro.declaration_year %}{{ declaration.intro.declaration_year }}, {% endif %}
 		{% if declaration.general.post.region %}{{ declaration.general.post.region }}, {% endif %}
@@ -30,7 +30,7 @@
 	</p>
 
 	<address>
-	P.S. Щоб відключити сповіщення перейдіть за <a href="https://declarations.com.ua/search-list/">посиланням</a>.
+	P.S. Щоб відключити сповіщення перейдіть за <a href="{{ site_url }}{% url 'search_list' %}">посиланням</a>.
 	</address>
 </body>
 </html>

--- a/declarations_site/spotter/templates/email_found_message.txt
+++ b/declarations_site/spotter/templates/email_found_message.txt
@@ -6,11 +6,11 @@
 {% for declaration in decl_list %}
 {{ declaration.general.last_name }} {{ declaration.general.name }} {{ declaration.general.patronymic }}
 {% if declaration.intro.declaration_year %}{{ declaration.intro.declaration_year}}, {% endif %}{% if declaration.general.post.region %}{{ declaration.general.post.region }}, {% endif %}{% if declaration.general.post.office %}{{ declaration.general.post.office }}, {% endif %}{% if declaration.general.post.post %}{{ declaration.general.post.post }}{% endif %}
-https://declarations.com.ua/declaration/{{ declaration.meta.id }}
+{{ site_url }}{% url 'details' declaration.meta.id %}
 {% endfor %}
 --
 З найкращими побажаннями,
 Команда declarations.com.ua
 
-P.S. Щоб відключити сповіщення перейдіть за посиланням: https://declarations.com.ua/search-list/
+P.S. Щоб відключити сповіщення перейдіть за посиланням: {{ site_url }}{% url 'search_list' %}
 {% endautoescape %}

--- a/declarations_site/spotter/templates/email_newtask_message.html
+++ b/declarations_site/spotter/templates/email_newtask_message.html
@@ -17,7 +17,7 @@
 	</p>
 
 	<address>
-	P.S. Щоб відключити сповіщення перейдіть за <a href="https://declarations.com.ua/search-list/">посиланням</a>.
+	P.S. Щоб відключити сповіщення перейдіть за <a href="{{ site_url }}{% url 'search_list' %}">посиланням</a>.
 	</address>
 </body>
 </html>

--- a/declarations_site/spotter/templates/email_newtask_message.txt
+++ b/declarations_site/spotter/templates/email_newtask_message.txt
@@ -9,5 +9,5 @@
 З найкращими побажаннями,
 Команда declarations.com.ua
 
-P.S. Щоб відключити сповіщення перейдіть за посиланням: https://declarations.com.ua/search-list/
+P.S. Щоб відключити сповіщення перейдіть за посиланням: {{ site_url }}{% url 'search_list' %}
 {% endautoescape %}

--- a/declarations_site/spotter/templates/login_menu.jinja
+++ b/declarations_site/spotter/templates/login_menu.jinja
@@ -1,10 +1,10 @@
 <div class="dropdown profile-dropdown pull-right">
-	<button class="btn btn-primary dropdown-toggle logged-in" type="button" id="profile" data-toggle="dropdown">
-	{% if request.user.first_name %}{{ request.user.first_name }} {{ request.user.last_name }}
-	{% else %}{{ request.user.username }}{% endif %} <span class="caret"></span></button>
-	<ul class="dropdown-menu">
-		<li><a href="{{ url("search_list") }}"><span class="glyphicon glyphicon-tasks"></span> Мої запити</a></li>
-		<li class="divider"></li>
-		<li><a href="{{ url("logout") }}" id="logout"><span class="glyphicon glyphicon-off"></span> Вийти</a></li>
-	</ul>
+    <button class="btn btn-primary dropdown-toggle logged-in" type="button" id="profile" data-toggle="dropdown">
+        {% if request.user.first_name %}{{ request.user.first_name }} {{ request.user.last_name }}
+        {% else %}{{ request.user.username }}{% endif %} <span class="caret"></span></button>
+    <ul class="dropdown-menu">
+        <li><a href="{{ url("search_list") }}"><span class="glyphicon glyphicon-tasks"></span> Мої запити</a></li>
+        <li class="divider"></li>
+        <li><a href="{{ url("logout") }}" id="logout"><span class="glyphicon glyphicon-off"></span> Вийти</a></li>
+    </ul>
 </div>

--- a/declarations_site/spotter/templates/search_list.jinja
+++ b/declarations_site/spotter/templates/search_list.jinja
@@ -1,5 +1,7 @@
 {% extends "base.jinja" %}
 
+{% from "_spotter.jinja" import flash_messages %}
+
 {% block html_title -%}Мої запити{%- endblock %}
 
 
@@ -12,17 +14,7 @@
                 <li class="active">Мої запити</li>
             </ol>
         </div>
-        {% if messages %}
-        <div class="messages">
-            {% for message in messages %}
-            <div class="alert alert-dismissible alert-{% if message.tags %}{{ message.tags }}{% endif %}">
-                <button type="button" class="close" data-dismiss="alert"
-                    aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                {{ message }}
-            </div>
-            {% endfor %}
-        </div>
-        {% endif %}
+        {{ flash_messages(messages) }}
         <h1 id="page-header"><span>Мої запити</span></h1>
         <div class="page-content">
             <div class="box">
@@ -82,8 +74,8 @@
                     </div>
                 </div>
             </div>
-            <p class="text-center">
-                <br><br>Щоб створити нове завдання спробуйте щось знайти, а потім нажміть "+ МОНІТОРИТИ ЦЕЙ ЗАПИТ".
+            <p class="text-center help-footer">
+                Щоб створити нове завдання спробуйте щось знайти, а потім нажміть "+ МОНІТОРИТИ ЦЕЙ ЗАПИТ".
             </p>
         </div>
     </div>

--- a/declarations_site/spotter/urls.py
+++ b/declarations_site/spotter/urls.py
@@ -5,6 +5,7 @@ from spotter import views as spotter_views
 urlpatterns = [
     url(r'logout/$', spotter_views.silent_logout, name='logout'),
     url(r'login-menu/$', spotter_views.login_menu, name='login_menu'),
+    url(r'edit-email/$', spotter_views.edit_email, name='edit_email'),
     url(r'save-search/$', spotter_views.save_search, name='save_search'),
     url(r'search-list/$', spotter_views.search_list, name='search_list'),
     url(r'edit-search/(?P<task_id>\d+)/$', spotter_views.edit_search, name='edit_search'),


### PR DESCRIPTION
- fix javascript unicode escape behaviour
- fix 500 crashes on social plugin errors
- fix typos in email links
- fix ui typos
- move typeahead js code to main.js
- add user edit email form for facebook users w/o emails
- cosmetic punctuations