### PR TITLE
Local dev execution improvements

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+declarations_bank/
+dragnet/
+declarations_site/static/sass/.sass-cache/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,13 +47,6 @@ services:
       - elasticsearch
       - couchdb
 
-  sync:
-    build: ./dragnet/couch2elastic4sync
-    env_file: ./dragnet/couch2elastic4sync/.local_env
-    depends_on:
-      - couchdb
-      - elasticsearch
-
   dragnet_utils:
     build: ./dragnet/utils
     volumes:
@@ -63,11 +56,6 @@ services:
       - ./declarations_bank:/mnt/declarations_bank
     depends_on:
       - couchdb
-      - elasticsearch
-
-  elasticdump:
-    image: taskrabbit/elasticsearch-dump:v3.3.0
-    depends_on:
       - elasticsearch
 
 volumes:


### PR DESCRIPTION
- Make telegram bot instance lazy load to avoid having a valid token on process boot
- Add .dockerignore to avoid sending e.g. whole declarations bank to the docker socket when building an image
- Remove unneeded stuff from docker-compose